### PR TITLE
Change php doc for createStreamedResponse

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -63,7 +63,7 @@ class Factory {
      * Return a StreamedResponse containing the file
      * 
      * @param Spreadsheet $spreadsheet
-     * @param unknown $type
+     * @param string $type
      * @param number $status
      * @param array $headers
      * @param array $writerOptions


### PR DESCRIPTION
IOFactory::createWriter expects $type to be a string https://github.com/PHPOffice/PhpSpreadsheet/blob/master/src/PhpSpreadsheet/IOFactory.php#L47

Having unknown in phpdoc generates error on phpstan