### PR TITLE
Remove deprecation message: A tree builder without a root node is depr…

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,8 +18,15 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $builder = new TreeBuilder();
-        $builder->root('yectep_phpoffice');
+        if (! method_exists('Symfony\Component\Config\Definition\Builder\TreeBuilder', 'getRootNode')) {
+            // This is the pre 4.2 way
+            $builder = new TreeBuilder();
+            $builder->root('yectep_phpoffice');
+        } else {
+            $builder = new TreeBuilder('yectep_phpoffice');
+            $builder->getRootNode($builder, 'yectep_phpoffice');
+        }
+
 
         return $builder;
     }


### PR DESCRIPTION
Since Symfony 4.2, there appears a deprecation message: "A tree builder without a root node is deprecated since Symfony 4.2".
This PR fixes the issue.