### PR TITLE
Fix Symfony 5 autowiring Factory service error

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -5,3 +5,6 @@ services:
     phpoffice.spreadsheet:
         class: '%phpofficebundle_spreadsheet_class%'
         public: true
+
+    '%phpofficebundle_spreadsheet_class%':
+        alias: phpoffice.spreadsheet


### PR DESCRIPTION
After moving project to Symfony 5, have got an error:

> Cannot autowire service "path\to\project\service\class": argument "$spreadsheetFactory" of method "__construct()" references class "Yectep\PhpSpreadsheetBundle\Factory" but no such service exists. You should maybe alias this class to the existing "phpoffice.spreadsheet" service.

Given commit will fix this issue.