### PR TITLE
Fix typehint to use built-in int instead of number

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -64,7 +64,7 @@ class Factory {
      * 
      * @param Spreadsheet $spreadsheet
      * @param string $type
-     * @param number $status
+     * @param int $status
      * @param array $headers
      * @param array $writerOptions
      * @return \Symfony\Component\HttpFoundation\StreamedResponse


### PR DESCRIPTION
Psalm code analysis fails, when calling with int instead of supposed Yectep\PhpSpreadsheetBundle\number