### PR TITLE
Add Symfony 6 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
-        "phpoffice/phpspreadsheet": "~1.1",
-        "symfony/framework-bundle": "~2.7|~3.0|~4.0|^5.0"
+        "php": ">=7.2",
+        "phpoffice/phpspreadsheet": "~1.16",
+        "symfony/framework-bundle": "~2.7|~3.0|~4.0|^5.0|^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @inheritdoc
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         if (! method_exists('Symfony\Component\Config\Definition\Builder\TreeBuilder', 'getRootNode')) {
             // This is the pre 4.2 way

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -5,6 +5,7 @@ namespace Yectep\PhpSpreadsheetBundle;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Writer\BaseWriter;
+use PhpOffice\PhpSpreadsheet\Writer\IWriter;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -23,7 +24,7 @@ class Factory {
      * @return Spreadsheet
      * @throws \PhpOffice\PhpSpreadsheet\Reader\Exception
      */
-    public function createSpreadsheet($filename = null)
+    public function createSpreadsheet($filename = null): Spreadsheet
     {
         return (is_null($filename) ? new Spreadsheet() : IOFactory::load($filename));
     }
@@ -37,7 +38,7 @@ class Factory {
      * @return \PhpOffice\PhpSpreadsheet\Writer\IWriter
      * @throws \PhpOffice\PhpSpreadsheet\Writer\Exception
      */
-    public function createWriter(Spreadsheet $spreadsheet, $type)
+    public function createWriter(Spreadsheet $spreadsheet, $type): IWriter
     {
         return IOFactory::createWriter($spreadsheet, $type);
     }
@@ -69,7 +70,7 @@ class Factory {
      * @param array $writerOptions
      * @return \Symfony\Component\HttpFoundation\StreamedResponse
      */
-    public function createStreamedResponse(Spreadsheet $spreadsheet, $type, $status = 200, $headers = array(), $writerOptions = array())
+    public function createStreamedResponse(Spreadsheet $spreadsheet, $type, $status = 200, $headers = array(), $writerOptions = array()): StreamedResponse
     {
         $writer = IOFactory::createWriter($spreadsheet, $type);
 

--- a/src/PhpSpreadsheetBundle.php
+++ b/src/PhpSpreadsheetBundle.php
@@ -3,6 +3,7 @@
 namespace Yectep\PhpSpreadsheetBundle;
 
 use Symfony\Component\HttpKernel\Bundle\Bundle;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 use Yectep\PhpSpreadsheetBundle\DependencyInjection\PhpSpreadsheetExtension;
 
 class PhpSpreadsheetBundle extends Bundle
@@ -11,7 +12,7 @@ class PhpSpreadsheetBundle extends Bundle
     /**
      * @inheritdoc
      */
-    public function getContainerExtension()
+    public function getContainerExtension(): ?ExtensionInterface
     {
         return new PhpSpreadsheetExtension();
     }


### PR DESCRIPTION
This PR allows Symfony 6 support.
It also increase minimum version for phpoffice/phpspreadsheet library since older versions contains security issues.
Upgrading PHP version was needed to add return type in methods (avoiding deprecations notices in Symfony 6) but it might break backward compatibility